### PR TITLE
Tweaked Changes file to satisfy CPAN::Changes::Spec

### DIFF
--- a/Changes
+++ b/Changes
@@ -12,7 +12,7 @@ Revision history for {{$dist->name}}
       it returns the string that will be
       written out.
 
-0.005
+0.005 2013-07-28
     - Make sure that our split spf records
       contain the protocol, v=spf1.
 


### PR DESCRIPTION
Hi,

I've reformatted your Changes file according to the spec in CPAN::Changes::Spec. The only thing wrong was a missing date for 0.005: I guessed the date (one of 3 possible), so please correct it if I got it wrong :-)

Following this format means that various tools can more easily process your distribution automatically.

You can find out more about this at Brian Cassidy's CPAN::Changes Kwalitee Service (http://changes.cpanhq.org), which is where I saw your module listed :-)

Cheers,
Neil
